### PR TITLE
Reflect now requires DynamicTypePath. Remove Reflect::get_type_path()…

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -200,11 +200,6 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             }
 
             #[inline]
-            fn get_type_path(&self) -> &dyn #bevy_reflect_path::DynamicTypePath {
-                self
-            }
-
-            #[inline]
             fn into_any(self: #FQBox<Self>) -> #FQBox<dyn #FQAny> {
                 self
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -175,11 +175,6 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn get_type_path(&self) -> &dyn #bevy_reflect_path::DynamicTypePath {
-                self
-            }
-
-            #[inline]
             fn into_any(self: #FQBox<Self>) -> #FQBox<dyn #FQAny> {
                 self
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -145,11 +145,6 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn get_type_path(&self) -> &dyn #bevy_reflect_path::DynamicTypePath {
-                self
-            }
-
-            #[inline]
             fn into_any(self: #FQBox<Self>) -> #FQBox<dyn #FQAny> {
                 self
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -57,11 +57,6 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             }
 
             #[inline]
-            fn get_type_path(&self) -> &dyn #bevy_reflect_path::DynamicTypePath {
-                self
-            }
-
-            #[inline]
             fn into_any(self: #FQBox<Self>) -> #FQBox<dyn #FQAny> {
                 self
             }

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,9 +1,8 @@
-use bevy_reflect_derive::impl_type_path;
-
 use crate::{
-    self as bevy_reflect, utility::reflect_hasher, DynamicTypePath, Reflect, ReflectMut,
-    ReflectOwned, ReflectRef, TypeInfo,
+    self as bevy_reflect, utility::reflect_hasher, Reflect, ReflectMut, ReflectOwned, ReflectRef,
+    TypeInfo,
 };
+use bevy_reflect_derive::impl_type_path;
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
@@ -224,11 +223,6 @@ impl Reflect for DynamicArray {
     #[inline]
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         self.represented_type
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -2,8 +2,8 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::{
     self as bevy_reflect, enum_debug, enum_hash, enum_partial_eq, DynamicStruct, DynamicTuple,
-    DynamicTypePath, Enum, Reflect, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo,
-    VariantFieldIter, VariantType,
+    Enum, Reflect, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, VariantFieldIter,
+    VariantType,
 };
 use std::any::Any;
 use std::fmt::Formatter;
@@ -298,11 +298,6 @@ impl Reflect for DynamicEnum {
     #[inline]
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         self.represented_type
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -4,9 +4,9 @@ use std::any::Any;
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
-    self as bevy_reflect, DynamicTypePath, FromReflect, FromType, GetTypeRegistration, List,
-    ListInfo, ListIter, Reflect, ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
-    TypePath, TypeRegistration, Typed,
+    self as bevy_reflect, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter,
+    Reflect, ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
+    TypeRegistration, Typed,
 };
 
 impl<T: smallvec::Array + TypePath + Send + Sync> List for SmallVec<T>
@@ -86,11 +86,6 @@ where
 
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -2,8 +2,8 @@ use crate::std_traits::ReflectDefault;
 use crate::{self as bevy_reflect, ReflectFromPtr, ReflectFromReflect, ReflectOwned};
 use crate::{
     impl_type_path, map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum,
-    DynamicMap, DynamicTypePath, Enum, EnumInfo, FromReflect, FromType, GetTypeRegistration, List,
-    ListInfo, ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
+    DynamicMap, Enum, EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo,
+    ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
     ReflectSerialize, TupleVariantInfo, TypeInfo, TypePath, TypeRegistration, Typed,
     UnitVariantInfo, UnnamedField, ValueInfo, VariantFieldIter, VariantInfo, VariantType,
 };
@@ -332,11 +332,6 @@ macro_rules! impl_reflect_for_veclike {
                 Some(<Self as Typed>::type_info())
             }
 
-            #[inline]
-            fn get_type_path(&self) -> &dyn DynamicTypePath {
-                self
-            }
-
             fn into_any(self: Box<Self>) -> Box<dyn Any> {
                 self
             }
@@ -555,10 +550,6 @@ macro_rules! impl_reflect_for_hashmap {
                 Some(<Self as Typed>::type_info())
             }
 
-            fn get_type_path(&self) -> &dyn DynamicTypePath {
-                self
-            }
-
             fn into_any(self: Box<Self>) -> Box<dyn Any> {
                 self
             }
@@ -719,11 +710,6 @@ impl<T: Reflect + TypePath, const N: usize> Reflect for [T; N] {
 
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     #[inline]
@@ -944,11 +930,6 @@ impl<T: FromReflect + TypePath> Reflect for Option<T> {
     }
 
     #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
-    }
-
-    #[inline]
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
@@ -1115,11 +1096,6 @@ impl Reflect for Cow<'static, str> {
         Some(<Self as Typed>::type_info())
     }
 
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
-    }
-
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
@@ -1252,11 +1228,6 @@ impl Reflect for &'static Path {
         Some(<Self as Typed>::type_info())
     }
 
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
-    }
-
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
@@ -1364,11 +1335,6 @@ impl FromReflect for &'static Path {
 impl Reflect for Cow<'static, Path> {
     fn type_name(&self) -> &str {
         std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -6,8 +6,7 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::utility::reflect_hasher;
 use crate::{
-    self as bevy_reflect, DynamicTypePath, FromReflect, Reflect, ReflectMut, ReflectOwned,
-    ReflectRef, TypeInfo,
+    self as bevy_reflect, FromReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
 };
 
 /// A trait used to power [list-like] operations via [reflection].
@@ -274,11 +273,6 @@ impl Reflect for DynamicList {
     #[inline]
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         self.represented_type
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -5,9 +5,7 @@ use std::hash::Hash;
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
 
-use crate::{
-    self as bevy_reflect, DynamicTypePath, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
-};
+use crate::{self as bevy_reflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo};
 
 /// A trait used to power [map-like] operations via [reflection].
 ///
@@ -308,11 +306,6 @@ impl Reflect for DynamicMap {
     #[inline]
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         self.represented_type
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -72,7 +72,7 @@ pub enum ReflectOwned {
 /// [`bevy_reflect`]: crate
 /// [derive macro]: bevy_reflect_derive::Reflect
 /// [crate-level documentation]: crate
-pub trait Reflect: Any + Send + Sync {
+pub trait Reflect: DynamicTypePath + Any + Send + Sync {
     /// Returns the [type name][std::any::type_name] of the underlying type.
     fn type_name(&self) -> &str;
 
@@ -92,14 +92,6 @@ pub trait Reflect: Any + Send + Sync {
     /// [`DynamicList`]: crate::DynamicList
     /// [`TypeRegistry::get_type_info`]: crate::TypeRegistry::get_type_info
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo>;
-
-    /// Returns the [`TypePath`] implementation for the underlying type.
-    ///
-    /// Methods on [`DynamicTypePath`] suffer the same performance concerns as [`get_represented_type_info`].
-    ///
-    /// [`TypePath`]: crate::TypePath
-    /// [`get_represented_type_info`]: Reflect::get_represented_type_info
-    fn get_type_path(&self) -> &dyn DynamicTypePath;
 
     /// Returns the value as a [`Box<dyn Any>`][std::any::Any].
     fn into_any(self: Box<Self>) -> Box<dyn Any>;

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,6 +1,5 @@
 use crate::{
-    self as bevy_reflect, DynamicTypePath, NamedField, Reflect, ReflectMut, ReflectOwned,
-    ReflectRef, TypeInfo,
+    self as bevy_reflect, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
 };
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
@@ -403,11 +402,6 @@ impl Reflect for DynamicStruct {
     #[inline]
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         self.represented_type
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,9 +1,9 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
-    self as bevy_reflect, utility::GenericTypePathCell, DynamicTypePath, FromReflect,
-    GetTypeRegistration, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
-    TypeRegistration, Typed, UnnamedField,
+    self as bevy_reflect, utility::GenericTypePathCell, FromReflect, GetTypeRegistration, Reflect,
+    ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypeRegistration, Typed,
+    UnnamedField,
 };
 use std::any::{Any, TypeId};
 use std::borrow::Cow;
@@ -322,11 +322,6 @@ impl Reflect for DynamicTuple {
     }
 
     #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
-    }
-
-    #[inline]
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
@@ -536,11 +531,6 @@ macro_rules! impl_reflect_tuple {
 
             fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
                 Some(<Self as Typed>::type_info())
-            }
-
-            #[inline]
-            fn get_type_path(&self) -> &dyn DynamicTypePath {
-                self
             }
 
             fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,8 +1,7 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
-    self as bevy_reflect, DynamicTypePath, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
-    UnnamedField,
+    self as bevy_reflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, UnnamedField,
 };
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
@@ -306,11 +305,6 @@ impl Reflect for DynamicTupleStruct {
     #[inline]
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         self.represented_type
-    }
-
-    #[inline]
-    fn get_type_path(&self) -> &dyn DynamicTypePath {
-        self
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -24,7 +24,7 @@ use std::fmt::Debug;
 ///
 /// ```
 /// # use std::any::Any;
-/// # use bevy_reflect::{DynamicTypePath, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, TypeInfo, ValueInfo};
+/// # use bevy_reflect::{DynamicTypePath, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, TypeInfo, TypePath, ValueInfo};
 /// # use bevy_reflect::utility::NonGenericTypeInfoCell;
 /// use bevy_reflect::Typed;
 ///
@@ -51,7 +51,6 @@ use std::fmt::Debug;
 /// # impl Reflect for MyStruct {
 /// #   fn type_name(&self) -> &str { todo!() }
 /// #   fn get_represented_type_info(&self) -> Option<&'static TypeInfo> { todo!() }
-/// #   fn get_type_path(&self) -> &dyn DynamicTypePath { todo!() }
 /// #   fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
 /// #   fn as_any(&self) -> &dyn Any { todo!() }
 /// #   fn as_any_mut(&mut self) -> &mut dyn Any { todo!() }
@@ -64,6 +63,11 @@ use std::fmt::Debug;
 /// #   fn reflect_mut(&mut self) -> ReflectMut { todo!() }
 /// #   fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// #   fn clone_value(&self) -> Box<dyn Reflect> { todo!() }
+/// # }
+/// #
+/// # impl TypePath for MyStruct {
+/// #   fn type_path() -> &'static str { todo!() }
+/// #   fn short_type_path() -> &'static str { todo!() }
 /// # }
 /// ```
 ///

--- a/crates/bevy_reflect/src/type_path.rs
+++ b/crates/bevy_reflect/src/type_path.rs
@@ -123,10 +123,6 @@ pub trait TypePath: 'static {
 }
 
 /// Dynamic dispatch for [`TypePath`].
-///
-/// Retrieved using [`Reflect::get_type_path`].
-///
-/// [`Reflect::get_type_path`]: crate::Reflect::get_type_path
 pub trait DynamicTypePath {
     /// See [`TypePath::type_path`].
     fn reflect_type_path(&self) -> &str;

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -50,7 +50,7 @@ mod sealed {
 ///
 /// ```
 /// # use std::any::Any;
-/// # use bevy_reflect::{DynamicTypePath, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, Typed, TypeInfo};
+/// # use bevy_reflect::{DynamicTypePath, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, Typed, TypeInfo, TypePath};
 /// use bevy_reflect::utility::NonGenericTypeInfoCell;
 ///
 /// struct Foo {
@@ -70,7 +70,6 @@ mod sealed {
 /// #
 /// # impl Reflect for Foo {
 /// #     fn type_name(&self) -> &str { todo!() }
-/// #     fn get_type_path(&self) -> &dyn DynamicTypePath { todo!() }
 /// #     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> { todo!() }
 /// #     fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
 /// #     fn as_any(&self) -> &dyn Any { todo!() }
@@ -84,6 +83,11 @@ mod sealed {
 /// #     fn reflect_mut(&mut self) -> ReflectMut { todo!() }
 /// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// #     fn clone_value(&self) -> Box<dyn Reflect> { todo!() }
+/// # }
+
+/// # impl TypePath for Foo {
+/// #   fn type_path() -> &'static str { todo!() }
+/// #   fn short_type_path() -> &'static str { todo!() }
 /// # }
 /// ```
 ///
@@ -124,7 +128,7 @@ impl<T: TypedProperty> NonGenericTypeCell<T> {
 ///
 /// ```
 /// # use std::any::Any;
-/// # use bevy_reflect::{DynamicTypePath, Reflect, ReflectMut, ReflectOwned, ReflectRef, TupleStructInfo, Typed, TypeInfo, UnnamedField};
+/// # use bevy_reflect::{DynamicTypePath, Reflect, ReflectMut, ReflectOwned, ReflectRef, TupleStructInfo, Typed, TypeInfo, TypePath, UnnamedField};
 /// use bevy_reflect::utility::GenericTypeInfoCell;
 ///
 /// struct Foo<T>(T);
@@ -142,7 +146,6 @@ impl<T: TypedProperty> NonGenericTypeCell<T> {
 /// #
 /// # impl<T: Reflect> Reflect for Foo<T> {
 /// #     fn type_name(&self) -> &str { todo!() }
-/// #     fn get_type_path(&self) -> &dyn DynamicTypePath { todo!() }
 /// #     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> { todo!() }
 /// #     fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
 /// #     fn as_any(&self) -> &dyn Any { todo!() }
@@ -156,6 +159,10 @@ impl<T: TypedProperty> NonGenericTypeCell<T> {
 /// #     fn reflect_mut(&mut self) -> ReflectMut { todo!() }
 /// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// #     fn clone_value(&self) -> Box<dyn Reflect> { todo!() }
+/// # }
+/// # impl<T: Reflect> TypePath for Foo<T> {
+/// #   fn type_path() -> &'static str { todo!() }
+/// #   fn short_type_path() -> &'static str { todo!() }
 /// # }
 /// ```
 ///
@@ -180,9 +187,8 @@ impl<T: TypedProperty> NonGenericTypeCell<T> {
 ///     }
 /// }
 /// #
-/// # impl<T: Reflect> Reflect for Foo<T> {
+/// # impl<T: Reflect + TypePath> Reflect for Foo<T> {
 /// #     fn type_name(&self) -> &str { todo!() }
-/// #     fn get_type_path(&self) -> &dyn DynamicTypePath { todo!() }
 /// #     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> { todo!() }
 /// #     fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
 /// #     fn as_any(&self) -> &dyn Any { todo!() }


### PR DESCRIPTION
… (#8764)

Followup to #7184

This makes `Reflect: DynamicTypePath` which allows us to remove `Reflect::get_type_path`, reducing unnecessary codegen and simplifying `Reflect` implementations.

# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #X".

## Solution

- Describe the solution used to achieve the objective above.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
