### PR TITLE
Disable camera on window close (#8802)

### DIFF
--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -31,12 +31,24 @@ impl Node for CameraDriverNode {
         world: &World,
     ) -> Result<(), NodeRunError> {
         let sorted_cameras = world.resource::<SortedCameras>();
+        let windows = world.resource::<ExtractedWindows>();
         let mut camera_windows = HashSet::new();
         for sorted_camera in &sorted_cameras.0 {
-            if let Ok(camera) = self.cameras.get_manual(world, sorted_camera.entity) {
-                if let Some(NormalizedRenderTarget::Window(window_ref)) = camera.target {
-                    camera_windows.insert(window_ref.entity());
+            let Ok(camera) = self.cameras.get_manual(world, sorted_camera.entity) else {
+                continue;
+            };
+
+            let mut run_graph = true;
+            if let Some(NormalizedRenderTarget::Window(window_ref)) = camera.target {
+                let window_entity = window_ref.entity();
+                if windows.windows.get(&window_entity).is_some() {
+                    camera_windows.insert(window_entity);
+                } else {
+                    // The window doesn't exist anymore so we don't need to run the graph
+                    run_graph = false;
                 }
+            }
+            if run_graph {
                 graph.run_sub_graph(
                     camera.render_graph.clone(),
                     vec![],


### PR DESCRIPTION
# Objective

- When a window is closed, the associated camera keeps rendering even if the RenderTarget isn't valid anymore.
	- This is essentially just wasting a lot of performance.

## Solution

- Detect the window close event and disable any camera that used the window has a RenderTarget.

## Notes

It's possible a similar thing could be done for camera that use an image handle, but I would fix that in a separate PR.

# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #X".

## Solution

- Describe the solution used to achieve the objective above.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
